### PR TITLE
Correcting the index file as per the correct convention

### DIFF
--- a/backend-fastify/src/websocket/index.js
+++ b/backend-fastify/src/websocket/index.js
@@ -65,6 +65,7 @@ export const setFastifyWebsocket = function () {
         });
         connection.socket.on("message", (message) => {
          // Instead of concatenating strings with the + operator, consider using template strings (backticks) for better readability.
+          
           console.log(`Web Socket - message ${parseMessage(message)}`);
           
         });

--- a/backend-fastify/src/websocket/index.js
+++ b/backend-fastify/src/websocket/index.js
@@ -64,7 +64,9 @@ export const setFastifyWebsocket = function () {
           console.log("*****************************  Web Socket - close *****************************");
         });
         connection.socket.on("message", (message) => {
-          console.log("Web Socket - message", parseMessage(message));
+         // Instead of concatenating strings with the + operator, consider using template strings (backticks) for better readability.
+          console.log(`Web Socket - message ${parseMessage(message)}`);
+          
         });
       }
     );


### PR DESCRIPTION
Instead of concatenating strings with the + operator, consider using template strings (backticks) for better readability.